### PR TITLE
Ability to set inner instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ![alt text](https://img.shields.io/github/workflow/status/grevend/singleton/Test%20Deno%20module?label=Tests "Tests")
 
 ## Example
+
 ```typescript
 const rand = singleton(Math.random);
 const first = rand.getInstance();

--- a/README.md
+++ b/README.md
@@ -11,3 +11,11 @@ const rand = singleton(Math.random);
 const first = rand.getInstance();
 const second = rand.getInstance(); // first === second
 ```
+
+#### Changing the inner instance
+```typescript
+  const str = singleton(() => "a");
+  const first = rand.getInstance(); // "a"
+  str.setInstance("b");
+  const second = rand.getInstance(); // "b", first !== second
+```

--- a/mod.ts
+++ b/mod.ts
@@ -1,8 +1,9 @@
-export type Singleton<I> = { getInstance: () => I };
+export type Singleton<I> = { getInstance: () => I, setInstance: (x: I) => I; };
 
 export default function singleton<I>(factory: () => I): Singleton<I> {
   let instance: I | null = null;
   return {
     getInstance: () => instance == null ? (instance = factory()) : instance,
+    setInstance: (x: I) => instance = x,
   };
 }

--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,4 @@
-export type Singleton<I> = { getInstance: () => I, setInstance: (x: I) => I; };
+export type Singleton<I> = { getInstance: () => I; setInstance: (x: I) => I };
 
 export default function singleton<I>(factory: () => I): Singleton<I> {
   let instance: I | null = null;

--- a/singleton.bundle.js
+++ b/singleton.bundle.js
@@ -2,6 +2,8 @@ function singleton(factory) {
     let instance = null;
     return {
         getInstance: ()=>instance == null ? instance = factory() : instance
+        ,
+        setInstance: (x)=>instance = x
     };
 }
 export { singleton as default };

--- a/test.ts
+++ b/test.ts
@@ -6,3 +6,10 @@ Deno.test("check single instance creation", () => {
   const value = rand.getInstance();
   assertEquals(value, rand.getInstance());
 });
+
+Deno.test("check setting inner instance", () => {
+  const str = singleton(()=>"a");
+  assertEquals(str.getInstance(), "a");
+  str.setInstance("b");
+  assertEquals(str.getInstance(), "b")
+});

--- a/test.ts
+++ b/test.ts
@@ -8,8 +8,8 @@ Deno.test("check single instance creation", () => {
 });
 
 Deno.test("check setting inner instance", () => {
-  const str = singleton(()=>"a");
+  const str = singleton(() => "a");
   assertEquals(str.getInstance(), "a");
   str.setInstance("b");
-  assertEquals(str.getInstance(), "b")
+  assertEquals(str.getInstance(), "b");
 });


### PR DESCRIPTION
As it stand you can't adjust the inner state object directly by assignment (after getInstance). there's no reason this shouldn't be possible.

```TypeScript
singleton.getInstance() = {..}; // error
singleton.setInstance(...); // works
```